### PR TITLE
feat: adding loading indicator to export

### DIFF
--- a/ui/pages/reports/index.html
+++ b/ui/pages/reports/index.html
@@ -41,7 +41,7 @@
     <div id="exportModal" class="modal">
         <div class="modal-content">
             <span class="close">&times;</span>
-            <h2>Export Data from Promethes</h2>
+            <h2>Export Data from Prometheus</h2>
             <form id="exportForm">
                 <div class="form-group">
                     <label for="expr">PromQL Expression:</label>

--- a/ui/pages/reports/index.html
+++ b/ui/pages/reports/index.html
@@ -66,7 +66,7 @@
                         <option value="iso8601">ISO 8601</option>
                         <option value="rfc2822">RFC 2822</option>
                         <option value="rfc3339">RFC 3339</option>
-                        <option value="friendly">Friend</option>
+                        <option value="friendly">Friendly</option>
                     </select>
                 </div>
                 <div class="form-group">

--- a/ui/pages/reports/index.html
+++ b/ui/pages/reports/index.html
@@ -35,10 +35,13 @@
         <h5>Export data from Prometheus as CSV, YAML, and more.</h5>
         <button id="openModalBtn">Export Data</button>
     </div>
+
+    <div id="loadingIndicator" class="loading-indicator"></div>
+
     <div id="exportModal" class="modal">
         <div class="modal-content">
             <span class="close">&times;</span>
-            <h2>Export Data from Prometheus</h2>
+            <h2>Export Data from Promethes</h2>
             <form id="exportForm">
                 <div class="form-group">
                     <label for="expr">PromQL Expression:</label>
@@ -63,7 +66,7 @@
                         <option value="iso8601">ISO 8601</option>
                         <option value="rfc2822">RFC 2822</option>
                         <option value="rfc3339">RFC 3339</option>
-                        <option value="friendly">Friendly</option>
+                        <option value="friendly">Friend</option>
                     </select>
                 </div>
                 <div class="form-group">
@@ -89,7 +92,7 @@
             <div id="results"></div>
         </div>
     </div>
-
+    
     <script src="/reports/script.js"></script>
 </body>
 </html>

--- a/ui/pages/reports/script.js
+++ b/ui/pages/reports/script.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const modal = document.getElementById("exportModal");
     const btn = document.getElementById("openModalBtn");
     const span = document.getElementsByClassName("close")[0];
+    const loadingIndicator = document.getElementById('loadingIndicator');
 
     
     modal.style.display = "none";
@@ -16,6 +17,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     document.getElementById('exportForm').addEventListener('submit', async function(event) {
         event.preventDefault();
+
+        // Start Spinner
+        loadingIndicator.style.display = 'block';
 
         const expr = document.getElementById('expr').value;
         const start = document.getElementById('start').value ? new Date(document.getElementById('start').value).toISOString() : null;
@@ -67,6 +71,9 @@ document.addEventListener('DOMContentLoaded', function() {
             document.body.removeChild(a);
         } catch (error) {
             document.getElementById('results').innerHTML = `<p style="color: red;">${error.message}</p>`;
+        } finally {
+            // Stop Spinner
+            loadingIndicator.style.display = 'none';
         }
     });
 

--- a/ui/pages/reports/style.css
+++ b/ui/pages/reports/style.css
@@ -93,6 +93,30 @@ button:hover {
     margin-top: 20px;
 }
 
+.loading-indicator {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border: 8px solid #f3f3f3; /* Cor do fundo do círculo */
+    border-top: 8px solid #3498db; /* Cor da borda animada */
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    animation: spin 1s linear infinite;
+    z-index: 1002;
+}
+
+@keyframes spin {
+    0% {
+        transform: translate(-50%, -50%) rotate(0deg);
+    }
+    100% {
+        transform: translate(-50%, -50%) rotate(360deg);
+    }
+}
+
 
 .modal {
     display: none;


### PR DESCRIPTION
**1. What this PR does / why we need it:**
This PR implements a loading indicator using pure CSS, ensuring a better user experience by providing feedback during asynchronous operations. The implementation avoids external dependencies, reducing potential security vulnerabilities and simplifying maintenance.

- [//]: # (- Describe your changes here)
I changed the export page by adding a div tag that will be the loading indicator. Then I changed the page's corresponding style file. Finally, I changed the script file, adding the loading logic to appear while the request is made.

![loading-with-modal](https://github.com/user-attachments/assets/39540206-c004-402a-8933-057e9c6c93b6)
![loading-without-modal](https://github.com/user-attachments/assets/6c7359a2-9691-4717-bf8a-c1a4f0b04122)


**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
