### PR TITLE
fix: Update app version in docs

### DIFF
--- a/src/utils/openapi.py
+++ b/src/utils/openapi.py
@@ -17,7 +17,7 @@ def openapi(app: FastAPI):
                     "providing additional features and addressing its limitations. "
                     "Running as a sidecar alongside the Prometheus server enables "
                     "users to extend the capabilities of the API.",
-        version="0.1.0",
+        version="0.1.1",
         contact={
             "name": "Hayk Davtyan",
             "url": "https://hayk96.github.io",


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Adds correct version (v1.0.1) in the OpenAPI definition file for Swagger and Redoc pages

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [x] Version updated in code, docs, and metadata.
