### PR TITLE
feat(api): Enable Web UI by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1 / 2025-01-17
+
+* [ENHANCEMENT] Added loading indicator using pure CSS, ensuring a better user experience by providing feedback during asynchronous operations. #13 
+* [BUGFIX] Fixed type definition of `remote_read` setting in the /configs API model. Added `enable_http2` property in JSON schema validation under `remote_read` setting. #11 
+* [BUGFIX] Fixed favicon.ico URL in https://docs.parosly.io/ page.
+* [CHANGE] Bumped [dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact) from 3 to 6. #1
+
 ## 0.1.0 / 2025-01-13
 
 * [ENHANCEMENT] Initial release of Parosly, based on the [prometheus-api](https://github.com/hayk96/prometheus-api) project. The respective proposal document is available [here](https://github.com/hayk96/prometheus-api/issues/64).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 mkdir docs/examples/docker/rules # this path is already included in .gitignore
-python3 main.py --rule.path docs/examples/docker/rules --prom.addr http://localhost:9090 --web.enable-ui=true
+python3 main.py --config.file docs/examples/docker/prometheus.yml --rule.path docs/examples/docker/rules --prom.addr http://localhost:9090
 ```
 
 We use [`ruff-action`](https://github.com/chartboost/ruff-action) for linting the code. This means the committed code can be reported by the linter when it exits with failures. In some cases, your changes can also be fixed or modified by the linter.

--- a/README.md
+++ b/README.md
@@ -166,9 +166,8 @@ Grafana dashboard JSON model is available [here](https://github.com/parosly/paro
 
 <!--Web UI -->
 ## Web UI
-The web user interface is disabled by default. As the Parosly project is specifically designed to extend the APIs 
-available to Prometheus, the UI serves as an optional add-on feature. It offers a convenient and flexible way to manage 
-Prometheus rules. To enable the web UI, the `--web.enable-ui=true` flag must be passed at the startup of the application.
+The web user interface is enabled by default but can be disabled using `--web.enable-ui=false`. It provides a convenient 
+and flexible way to manage Prometheus configurations, rules, and more.
 
 ![](docs/images/ui.png)
 

--- a/docs/examples/docker/docker-compose.yml
+++ b/docs/examples/docker/docker-compose.yml
@@ -24,4 +24,3 @@ services:
       - --prom.addr=http://prometheus:9090
       - --config.file=/app/prometheus.yml
       - --rule.path=/app/rules
-      - --web.enable-ui=true

--- a/docs/examples/kubernetes/helm/values.yaml
+++ b/docs/examples/kubernetes/helm/values.yaml
@@ -23,7 +23,6 @@ server:
         - --web.listen-address=0.0.0.0:9090
         - --config.file=/config/prometheus.yml
         - --rule.path=/rules
-        - --web.enable-ui=true
        ports:
          - name: http
            containerPort: 9090

--- a/src/utils/arguments.py
+++ b/src/utils/arguments.py
@@ -66,7 +66,7 @@ def arg_parser() -> dict:
         "--web.enable-ui",
         required=False,
         type=str,
-        default="false",
+        default="true",
         choices=["true", "false"],
         help="enable web management UI"
     )


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- The web user interface is enabled by default. It can be disabled using `--web.enable-ui=false` flag.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [ ] Version updated in code, docs, and metadata.
