### PR TITLE
fix(api): Set httpx timeout value to 'never'

### DIFF
--- a/src/api/v1/endpoints/reverse_proxy.py
+++ b/src/api/v1/endpoints/reverse_proxy.py
@@ -17,6 +17,7 @@ async def _reverse_proxy(request: Request):
     url = httpx.URL(path=request.url.path,
                     query=request.url.query.encode("utf-8"))
     rp_req = client.build_request(request.method, url,
+                                  timeout=None,
                                   headers=request.headers.raw,
                                   content=await request.body())
     rp_resp = await client.send(rp_req, stream=True)


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- This PR sets httpx request timeout value to `None` (never) to handle Live Notifications (`/api/v1/notifications/live`) that was introduced in Prometheus v3.0.0

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [ ] Version updated in code, docs, and metadata.
