### PR TITLE
fix(schemas): Add filter_external_labels property under remote_read setting

### DIFF
--- a/src/schemas/configs.json
+++ b/src/schemas/configs.json
@@ -1157,6 +1157,10 @@
           "tls_config": {
             "$ref": "#/definitions/tls_config"
           },
+          "filter_external_labels": {
+            "type": "boolean",
+            "default": true
+          },
           "proxy_url": {
             "description": "Optional proxy URL.",
             "type": ["string", "null"],


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Adds `filter_external_labels` parameter in `remote_read` setting with `boolean` type.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [ ] Version updated in code, docs, and metadata.
