### PR TITLE
fix(dockerfile): fix legacy instructions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine
 LABEL maintainer="Hayk Davtyan <hayk@parosly.io>"
-ENV TZ UTC
-WORKDIR app
+ENV TZ=UTC
+WORKDIR /app
 COPY . .
 RUN python -m pip install --no-cache-dir -r requirements.txt
 EXPOSE 5000


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Changed from legacy ` ENV key value` format to the modern `ENV key=value `format for better compatibility and parsing clarity.
- Updated `WORKDIR app` to use an absolute path `WORKDIR /app` to ensure consistent behavior regardless of the base image.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [ ] Version updated in code, docs, and metadata.
