### PR TITLE
fix(api): Fix default value of step field and use auto resolution

### DIFF
--- a/src/api/v1/endpoints/export.py
+++ b/src/api/v1/endpoints/export.py
@@ -69,8 +69,10 @@ async def export(
         format: str = "csv"
 ):
     data = data.dict()
-    expr, start = data.get("expr"), data.get("start")
-    end, step = data.get("end"), data.get("step")
+    expr = data.get("expr")
+    start, end = data.get("start"), data.get("end")
+    step = data["step"] = exp.auto_max_resolution(
+        start, end) if data.get("step") == "auto" else data.get("step")
     file, file_format = None, format.lower()
     custom_fields, timestamp_format = data.get(
         "replace_fields"), data.get("timestamp_format")
@@ -95,6 +97,7 @@ async def export(
         extra={
             "status": response.status_code,
             "query": expr,
+            "step": step,
             "method": request.method,
             "request_path": f"{request.url.path}{'?' + request.url.query if request.url.query else ''}"})
     if sts == "success":

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -2,6 +2,7 @@ from src.utils.arguments import arg_parser
 from email.utils import formatdate
 from datetime import datetime
 from uuid import uuid4
+from math import ceil
 import requests
 import json
 import yaml
@@ -64,6 +65,19 @@ def format_timestamp(timestamp, fmt) -> str:
     }
 
     return timestamp_formats[fmt]
+
+
+def auto_max_resolution(start: str, end: str) -> str:
+    """
+    This function calculates the best step value based
+    on the Prometheus maximum resolution of 11,000
+    points per time-series.
+    """
+    date_format = "%Y-%m-%dT%H:%M:%SZ"
+    start_timestamp = datetime.strptime(start, date_format).timestamp()
+    end_timestamp = datetime.strptime(end, date_format).timestamp()
+    step_in_seconds = ceil((end_timestamp - start_timestamp) / 11000)
+    return f"{abs(step_in_seconds)}s"
 
 
 def data_processor(source_data: dict,

--- a/src/models/export.py
+++ b/src/models/export.py
@@ -1,12 +1,12 @@
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field
 from typing import Optional
 
 
 class ExportData(BaseModel, extra=Extra.allow):
     expr: str
-    start: Optional[str] = None
-    end: Optional[str] = None
-    step: Optional[str] = None
+    start: str = Field(regex=r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+    end: str = Field(regex=r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+    step: Optional[str] = "auto"
     timestamp_format: Optional[str] = "unix"
     replace_fields: Optional[dict] = dict()
     _request_body_examples = {


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Fixed the default value of the `step` property in the Export API. Now it takes value: `auto` with a string type, which calculates the best maximum resolution value based on the Prometheus maximum resolution of 11,000 points per time-series
- The `start` and `end` properties are required now

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [ ] Version updated in code, docs, and metadata.
